### PR TITLE
solid系ごとにDBを分けないようにした(primaryのみ使用)

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -10,8 +10,8 @@ test:
 
 production:
   adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
+  # connects_to:
+    # database:
+      # writing: cable
   polling_interval: 0.1.seconds
   message_retention: 1.day

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -12,5 +12,5 @@ test:
   <<: *default
 
 production:
-  database: cache
+  # database: cache
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
solid系は使用するが、とりあえずDBは分けない形とした。