### PR TITLE
Rails 8.1.2で互換性の問題が解決されたため minitestのバージョン固定を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,5 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
-  # minitestは使用していないが、依存関係でインストールされ、Railsとの互換性でCIが落ちるためバージョンを指定
-  gem 'minitest', '~> 5.0'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
-  minitest (~> 5.0)
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト依存関係を最適化しました。テストグループの明示的なテストフレームワーク依存関係の指定を削除し、既存のRails互換性とテストツーリング依存関係のみを保持するよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->