### PR TITLE
fix: デプロイ失敗

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -10,6 +10,8 @@ proxy:
   ssl: true
   host: icon-font-mashup.com
 
+deploy_timeout: 60
+
 registry:
   server: ghcr.io
   username: mousu-a


### PR DESCRIPTION
timeout設定だが、デフォルトの30秒だとタイムアウトまでにRailsが起動しないことがあり、デプロイが失敗判定されてしまうことがあるので60秒にした

### まとめ
それでもデプロイに失敗した。
リモートのシークレットキーをローカルと同じものになるよう更新したところデプロイに成功。
秘密キーが違ったことが原因で、タイムアウトは関係なかったのかも？（後々わかったことだが関係なくもなかった。30秒は結構シビアな時間で、マイグレーションなどがあると大体失敗する。最終的には120秒にした）

---
### ログ
それでもデプロイに失敗する。
ローカルで`kamal deploy`を実行してみたところ成功。
リモートはRailsアプリの起動時間に1分以上かかっており（タイムアウトは1分なので）、明らかにRailsサーバーの起動時間が遅い。

リモートのシークレットキーをローカルと同じものになるよう更新した。
成功した。
秘密キーが違ったことが原因で、タイムアウトは関係なかったのかも。

### 追記
ローカルでタイムアウトを30秒に戻して試したところ、デプロイに失敗したのでこの修正もあながち間違いでもなさそう。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア（Chores）**
  * デプロイメントのタイムアウト設定を追加しました。これにより、デプロイメントプロセスの実行時間が制御されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->