### PR TITLE
CI テスト実行前に databaseのセットアップとassets:precompileを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   scan_ruby:
@@ -83,7 +83,9 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -101,9 +103,6 @@ jobs:
         run: bin/rails assets:precompile
 
       - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
         run: bin/rspec
 
       - name: Keep screenshots from failed system tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,76 +4,58 @@ on:
   pull_request:
   push:
     branches: [main]
-
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
-
   scan_js:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: bin/importmap audit
-
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "npm"
-
       - name: Install JavaScript dependencies
         run: npm ci
-
       - name: Run RuboCop
         run: bin/rubocop -f github
-
       - name: Run Slim Lint
         run: bundle exec slim-lint app/views
-
       - name: Run ESLint
         run: npm run -s lint:eslint
-
       - name: Run Prettier Lint
         run: npm run -s lint:prettier
-
   test:
     runs-on: ubuntu-latest
-
     services:
       postgres:
         image: postgres
@@ -89,22 +71,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Setup database
         run: bin/rails db:prepare
-
       - name: Assets precompile
         run: bin/rails assets:precompile
-
       - name: Run tests
         run: bin/rspec
-
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v7
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,17 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Setup database
+        run: bin/rails db:prepare
+
+      - name: Assets precompile
+        run: bin/rails assets:precompile
+
       - name: Run tests
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-        run: |
-          bin/rails db:test:prepare
-          bin/rspec
+        run: bin/rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
- #183
bin/rails db:test:prepareはmigrationのチェックは行うが、migrationの実行はしてくれないため現在の主流であるbundle exec rails db:prepareに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストデータベースの準備とアセットのプリコンパイルプロセスを最適化し、CI ワークフローを改善しました。これにより、テスト実行がより効率的に行われるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mousu-a/combine_icons_with_text/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->