### PR TITLE
ci.yml database setupの設定を調整

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,12 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
         env:
+          POSTGRES_DB: combine_icons_with_text_test
           POSTGRES_USER: rails
           POSTGRES_PASSWORD: password
     env:
       RAILS_ENV: test
-      DATABASE_URL: postgres://rails:password@localhost:5432
+      DATABASE_URL: postgres://rails:password@localhost:5432/combine_icons_with_text_test
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,15 +59,15 @@ jobs:
     services:
       postgres:
         image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+        env:
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
     env:
       RAILS_ENV: test
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      DATABASE_URL: postgres://rails:password@localhost:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
間違ったDBに接続する可能性があるためDBを指定するように
あとはデフォだとわかりにくかったのでそれぞれに名前をつけるなど