### PR TITLE
ヘルスチェックのデフォルトタイムアウトを伸ばす

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -10,7 +10,7 @@ proxy:
   ssl: true
   host: icon-font-mashup.com
 
-deploy_timeout: 60
+deploy_timeout: 120
 
 registry:
   server: ghcr.io


### PR DESCRIPTION
マイグレーションがあるPRをマージすると必ずと言っていいほどデプロイが失敗するので
ログを見たところタイムアウトしたあとにRailsサーバーが起動していたので、タイムアウトまでの時間を伸ばすことに。