### PR TITLE
画像を保存した時、リダイレクトをせず、トーストでメッセージを表示するようにした

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,3 +22,17 @@
 .avatar-icon {
   cursor: pointer;
 }
+
+/* TODO: デザイン　動作確認をしやすいようとりあえず入れた */
+.toast {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 1000;
+
+  padding: 12px 16px;
+  border-radius: 8px;
+
+  background: #333;
+  color: #fff;
+}

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -23,7 +23,7 @@ class IconsController < ApplicationController
     if @user_icons.save_all(original_icon_params, combined_icon_params)
       render json: { message: '画像を保存しました。' }, status: :ok
     else
-      render json: { message: @user_icons.errors.full_messages }, status: :unprocessable_content
+      render json: { message: @user_icons.errors.full_messages.join("\n") }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -23,7 +23,7 @@ class IconsController < ApplicationController
     if @user_icons.save_all(original_icon_params, combined_icon_params)
       render json: { message: '画像を保存しました。' }, status: :ok
     else
-      render json: { message: @user_icons.errors.full_messages.join("\n") }, status: :unprocessable_content
+      render json: { error_message: @user_icons.errors.full_messages.join("\n") }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -17,14 +17,13 @@ class IconsController < ApplicationController
 
   def create
     save_canvas_preset(canvas_preset_params)
-    return render_redirect_path unless current_user
+    return render json: { message: '画像をダウンロードしました。' }, status: :ok unless current_user
 
     @user_icons = UserIcons.new(current_user)
     if @user_icons.save_all(original_icon_params, combined_icon_params)
-      flash[:notice] = '画像を保存しました！'
-      render_redirect_path
+      render json: { message: '画像を保存しました。' }, status: :ok
     else
-      render json: { error: @user_icons.errors.full_messages }, status: :unprocessable_content
+      render json: { message: @user_icons.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -64,9 +63,5 @@ class IconsController < ApplicationController
 
   def save_canvas_preset(preset_params)
     ActiveSupport::Notifications.instrument('icons.create', canvas_preset_params: preset_params)
-  end
-
-  def render_redirect_path
-    render json: { redirect_url: icons_path }
   end
 end

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["uploadedIcon", "originalImage"];
+  static targets = ["uploadedIcon", "originalImage", "toast", "toastMessage"];
 
   async submit(event) {
     const fd = setupFormdata(event.detail);
@@ -17,9 +17,9 @@ export default class extends Controller {
       });
       const responseData = await response.json();
       if (response.ok) {
-        window.location.href = responseData.redirect_url;
+        this.displayToast(responseData.message);
       } else {
-        alert(responseData.error || "画像の保存に失敗しました。");
+        alert(responseData.message);
         // TODO: ユーザーのネクストアクションを誘導する
         // https://github.com/mousu-a/combine_icons_with_text/issues/127
       }
@@ -29,6 +29,15 @@ export default class extends Controller {
       // TODO: ユーザーのネクストアクションを誘導する
       // https://github.com/mousu-a/combine_icons_with_text/issues/127
     }
+  }
+
+  displayToast(message) {
+    this.toastMessageTarget.textContent = message;
+    this.toastTarget.classList.remove("is-hidden");
+
+    setTimeout(() => {
+      this.toastTarget.classList.add("is-hidden");
+    }, 3000);
   }
 }
 

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
       if (response.ok) {
         this.displayToast(responseData.message);
       } else {
-        alert(responseData.message);
+        alert(responseData.error_message);
         // TODO: ユーザーのネクストアクションを誘導する
         // https://github.com/mousu-a/combine_icons_with_text/issues/127
       }

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["uploadedIcon", "originalImage", "toast", "toastMessage"];
+  static targets = ["toast", "toastMessage"];
 
   async submit(event) {
     const fd = setupFormdata(event.detail);

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -12,6 +12,9 @@ div(
   data-icons-canvas-outlet='.canvas'
   data-icons-preview-outlet='.preview'
   )
+  #toast
+    = render 'layouts/toast'
+
   label for='upload-icon' アイコンをアップロード
   input#upload-icon type='file' accept='image/*' data-icons-target='uploadedIcon' data-action='change->icons#setup'
   h3 元画像

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -4,6 +4,8 @@
       - @user_icons.errors.full_messages.each do |msg|
         li = msg
 
+= link_to 'アイコン一覧へ', icons_path
+
 h2 アイコン合成
 div(
   class='canvas preview'

--- a/app/views/layouts/_toast.html.slim
+++ b/app/views/layouts/_toast.html.slim
@@ -1,3 +1,3 @@
-.toast.is-hidden data-icons-form-target='toast'
+.toast.is-hidden data-icons-form-target='toast' role='status' aria-live='polite' aria-atomic='true'
   p data-icons-form-target='toastMessage'
     | 画像を保存しました。

--- a/app/views/layouts/_toast.html.slim
+++ b/app/views/layouts/_toast.html.slim
@@ -1,0 +1,3 @@
+.toast.is-hidden data-icons-form-target='toast'
+  p data-icons-form-target='toastMessage'
+    | 画像を保存しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,17 +23,17 @@ ja:
             base:
               limit_per_user: "元アイコンを保存できるのは%{max_icons_count}個までです"
             image:
-              file_too_large: "元アイコンは%{max_file_size}MB以下のファイルを選択してください"
+              file_too_large: "は%{max_file_size}MB以下のファイルを選択してください"
         combined_icon:
           attributes:
             base:
               limit_per_user: "合成アイコンを保存できるのは、1つの元アイコンごとに%{max_icons_count}個までです"
             image:
-              file_too_large: "申し訳ありません、合成アイコンがサイズ制限を超えてしまっています。\n合成アイコンは%{max_file_size}MB以下のファイルでお願いします。"
+              file_too_large: "がサイズ制限を超えてしまっています。\n申し訳ありませんが、合成アイコンは%{max_file_size}MB以下になりますようお願いします。"
       messages:
         limit_per_user: "元アイコンを保存できるのは%{max_icons_count}個までです"
         invalid_content_type: "%{content_type} は許可されていない形式です"
-        blank: が空のようです
+        blank: を入力してください
         taken: はすでに存在しています
   users:
     guest: ゲスト

--- a/spec/models/combined_icon_spec.rb
+++ b/spec/models/combined_icon_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CombinedIcon do
 
     it 'is invalid' do
       expect(combined_icon).not_to be_valid
-      expect(combined_icon.errors[:image]).to include("申し訳ありません、合成アイコンがサイズ制限を超えてしまっています。\n合成アイコンは#{CombinedIcon::MAX_FILE_SIZE}MB以下のファイルでお願いします。")
+      expect(combined_icon.errors[:image]).to include("がサイズ制限を超えてしまっています。\n申し訳ありませんが、合成アイコンは#{CombinedIcon::MAX_FILE_SIZE}MB以下になりますようお願いします。")
     end
   end
 end

--- a/spec/models/original_icon_spec.rb
+++ b/spec/models/original_icon_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe OriginalIcon do
 
       it 'is invalid' do
         expect(original_icon).not_to be_valid
-        expect(original_icon.errors[:image]).to include("元アイコンは#{OriginalIcon::MAX_FILE_SIZE}MB以下のファイルを選択してください")
+        expect(original_icon.errors[:image]).to include("は#{OriginalIcon::MAX_FILE_SIZE}MB以下のファイルを選択してください")
       end
     end
   end


### PR DESCRIPTION
- #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * トースト通知を追加：アイコン保存時の完了メッセージやエラーが画面右上に自動でポップアップ表示され、数秒後に消えます。
  * 保存後のページリダイレクトを廃止し、トーストで完了を知らせるUXに変更しました。
* **改善**
  * アイコンアップロード画面にアイコン一覧へのリンクを追加しました。
* **ローカライズ**
  * 日本語のバリデーション文言をより自然な表現に更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mousu-a/combine_icons_with_text/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->