### PR TITLE
すでにアイコンが制限いっぱいまで保存されている場合、これ以上は保存できない旨のメッセージを表示するようにした

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -13,7 +13,7 @@ class IconsController < ApplicationController
   def new
     @canvas_presets = CanvasPreset.order(created_at: :desc).limit(5)
     @user_icons = nil
-    @original_icon = current_user.original_icons.find(params[:original_icon_id]) if params[:original_icon_id]
+    @original_icon = current_user.original_icons.find_by(id: params[:original_icon_id])
     @limit_reached = current_user&.icons_limit_reached?(target_icon: @original_icon)
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -13,7 +13,7 @@ class IconsController < ApplicationController
   def new
     @canvas_presets = CanvasPreset.order(created_at: :desc).limit(5)
     @user_icons = nil
-    @original_icon = current_user.original_icons.find_by(id: params[:original_icon_id])
+    @original_icon = current_user.original_icons.find(params[:original_icon_id]) if params[:original_icon_id]
     @limit_reached = current_user&.icons_limit_reached?(target_icon: @original_icon)
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -14,11 +14,12 @@ class IconsController < ApplicationController
     @canvas_presets = CanvasPreset.order(created_at: :desc).limit(5)
     @user_icons = nil
     @original_icon = current_user.original_icons.find(params[:original_icon_id]) if params[:original_icon_id]
+    @limit_reached = current_user&.icons_limit_reached?(target_icon: @original_icon)
   end
 
   def create
     save_canvas_preset(canvas_preset_params)
-    return render json: { message: '画像をダウンロードしました。' }, status: :ok unless current_user
+    return render json: { message: '画像をダウンロードしました。' }, status: :ok unless current_user&.saveable?(original_icon_params)
 
     @user_icons = UserIcons.new(current_user)
     if @user_icons.save_all(original_icon_params, combined_icon_params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,17 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :uid, uniqueness: { scope: :provider }
   validates :uid, :provider, presence: true
+
+  def saveable?(original_icon_params)
+    original_icon = original_icons.find_by(id: original_icon_params[:id])
+    !icons_limit_reached?(target_icon: original_icon)
+  end
+
+  def icons_limit_reached?(target_icon: nil)
+    if target_icon
+      target_icon.combined_icons.count >= CombinedIcon::MAX_COMBINED_ICONS_COUNT
+    else
+      original_icons.count >= OriginalIcon::MAX_ORIGINAL_ICONS_COUNT
+    end
+  end
 end

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -4,6 +4,16 @@
       - @user_icons.errors.full_messages.each do |msg|
         li = msg
 
+- if @limit_reached
+  p
+    | すでにサイト上に、アイコンが上限まで保存されております。
+    br
+    | 合成やダウンロードは問題なくご使用いただけますが、新たにアイコンを保存することはできませんのでご注意ください。
+    br
+    | 新しく保存したい場合は、お手数ですが、先に既にあるアイコンを
+    = link_to 'アイコン一覧', icons_path
+    | にて削除していただければと思います。
+
 = link_to 'アイコン一覧へ', icons_path
 
 h2 アイコン合成

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  subject(:user) { create(:user) }
+
+  describe '#icons_limit_reached?' do
+    context 'when target_icon is present' do
+      subject(:icons_limit_reached?) { user.icons_limit_reached?(target_icon: original_icon) }
+
+      let!(:original_icon) { create(:original_icon, user:) }
+
+      it 'returns false before reaching the limit' do
+        create_list(
+          :combined_icon,
+          CombinedIcon::MAX_COMBINED_ICONS_COUNT - 1,
+          original_icon:
+        )
+
+        expect(icons_limit_reached?).to be(false)
+      end
+
+      it 'returns true after reaching the limit' do
+        create_list(
+          :combined_icon,
+          CombinedIcon::MAX_COMBINED_ICONS_COUNT,
+          original_icon:
+        )
+
+        expect(icons_limit_reached?).to be(true)
+      end
+    end
+
+    context 'when target_icon is absent' do
+      subject(:icons_limit_reached?) { user.icons_limit_reached?(target_icon: nil) }
+
+      it 'returns false before reaching the limit' do
+        create_list(
+          :original_icon,
+          OriginalIcon::MAX_ORIGINAL_ICONS_COUNT - 1,
+          user:
+        )
+
+        expect(icons_limit_reached?).to be(false)
+      end
+
+      it 'returns true after reaching the limit' do
+        create_list(
+          :original_icon,
+          OriginalIcon::MAX_ORIGINAL_ICONS_COUNT,
+          user:
+        )
+
+        expect(icons_limit_reached?).to be(true)
+      end
+    end
+  end
+
+  describe '#saveable?' do
+    subject(:saveable?) { user.saveable?(original_icon_params) }
+
+    context 'when original_icon id is present' do
+      let(:original_icon_params) { { id: original_icon.id } }
+      let!(:original_icon) { create(:original_icon, user:) }
+
+      it 'returns true when the found original_icon has not reached the combined_icon limit' do
+        create_list(
+          :combined_icon,
+          CombinedIcon::MAX_COMBINED_ICONS_COUNT - 1,
+          original_icon:
+        )
+
+        expect(saveable?).to be(true)
+      end
+
+      it 'returns false when the found original_icon has reached the combined_icon limit' do
+        create_list(
+          :combined_icon,
+          CombinedIcon::MAX_COMBINED_ICONS_COUNT,
+          original_icon:
+        )
+
+        expect(saveable?).to be(false)
+      end
+    end
+
+    context 'when original_icon id is absent' do
+      let(:original_icon_params) { { image: fixture_file_upload('spec/files/dummy_3MB.jpg', 'image/jpeg') } }
+
+      it 'returns true when the user has not reached the original_icon limit' do
+        create_list(
+          :original_icon,
+          OriginalIcon::MAX_ORIGINAL_ICONS_COUNT - 1,
+          user:
+        )
+
+        expect(saveable?).to be(true)
+      end
+    end
+
+    context 'when original_icon id is present but does not exist' do
+      let(:original_icon_params) { { id: 99_999 } }
+
+      it 'returns true when the user has not reached the original_icon limit' do
+        create_list(
+          :original_icon,
+          OriginalIcon::MAX_ORIGINAL_ICONS_COUNT - 1,
+          user:
+        )
+
+        expect(saveable?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
ダウンロードまでしてからそれを知らされるとガッカリなので
このアプリではそこまで(手間がないため)被害はないがこの方が親切。
- #118 
