### PR TITLE
サイトに保存した既存のアイコンを元に合成する機能を追加

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -13,6 +13,7 @@ class IconsController < ApplicationController
   def new
     @canvas_presets = CanvasPreset.order(created_at: :desc).limit(5)
     @user_icons = nil
+    @original_icon = current_user.original_icons.find(params[:original_icon_id]) if params[:original_icon_id]
   end
 
   def create
@@ -50,7 +51,7 @@ class IconsController < ApplicationController
   end
 
   def original_icon_params
-    params.expect(original_icon: [:image])
+    params.expect(original_icon: %i[id image])
   end
 
   def combined_icon_params

--- a/app/javascript/controllers/icons_controller.js
+++ b/app/javascript/controllers/icons_controller.js
@@ -3,20 +3,24 @@ import { Controller } from "@hotwired/stimulus";
 const MAX_FILE_SIZE_MB = 5;
 
 export default class extends Controller {
-  static targets = ["uploadedIcon", "originalImage", "downloadLink"];
+  static targets = [
+    "uploadedIcon",
+    "originalImage",
+    "downloadLink",
+    "existingIcon",
+  ];
   static outlets = ["preview", "canvas"];
 
-  setup() {
-    const file = this.uploadedIconTarget.files[0];
-
-    if (!this.validateFile(file)) {
-      alert(`${this.errorMessage}`);
-      return;
+  connect() {
+    if (this.hasExistingIconTarget) {
+      this.hasExistingIcon = true;
+      this.setup();
     }
+  }
 
-    this.baseImageUrl = URL.createObjectURL(file);
+  setup() {
+    this.baseImageUrl = this.setupOriginalImageUrl();
     const originalImage = this.originalImageTarget;
-
     originalImage.src = this.baseImageUrl;
     originalImage.style.display = "inline";
 
@@ -25,9 +29,22 @@ export default class extends Controller {
     };
   }
 
+  setupOriginalImageUrl() {
+    if (this.hasExistingIcon)
+      return this.existingIconTarget.dataset.originalIconUrl;
+
+    const file = this.uploadedIconTarget.files[0];
+    if (!this.validateFile(file)) {
+      alert(`${this.errorMessage}`);
+      throw new Error(this.errorMessage);
+    }
+    return URL.createObjectURL(file);
+  }
+
   validateFile(file) {
     this.errorMessage = null;
     const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp"];
+    // file.nameがない？
     const fileExtension = file.name.split(".").pop().toLowerCase();
 
     if (fileExtension === "heic" || fileExtension === "heif") {
@@ -75,17 +92,18 @@ export default class extends Controller {
   }
 
   async triggerSubmit(combinedImageName) {
-    const originalImageFile = this.uploadedIconTarget.files[0];
-    const renderPlan = this.canvasOutlet.renderPlan;
-    let combinedImageFile = this.canvasOutlet.canvasBlob;
+    const params = {};
+    if (this.hasExistingIcon) {
+      params.originalImageId = this.existingIconTarget.dataset.originalIconId;
+    } else {
+      params.originalImageFile = this.uploadedIconTarget.files[0];
+    }
+    params.combinedImageFile = this.canvasOutlet.canvasBlob;
+    params.combinedImageName = combinedImageName;
+    params.renderPlan = this.canvasOutlet.renderPlan;
 
     this.dispatch("download", {
-      detail: {
-        originalImageFile,
-        combinedImageFile,
-        combinedImageName,
-        renderPlan,
-      },
+      detail: { params },
     });
   }
 

--- a/app/javascript/controllers/icons_controller.js
+++ b/app/javascript/controllers/icons_controller.js
@@ -4,7 +4,7 @@ const MAX_FILE_SIZE_MB = 5;
 
 export default class extends Controller {
   static targets = [
-    "uploadedIcon",
+    "uploadedImage",
     "originalImage",
     "downloadLink",
     "existingIcon",
@@ -12,16 +12,13 @@ export default class extends Controller {
   static outlets = ["preview", "canvas"];
 
   connect() {
-    if (this.hasExistingIconTarget) {
-      this.hasExistingIcon = true;
-      this.setup();
-    }
+    if (this.hasExistingIconTarget) this.setup(null, this.existingIconTarget);
   }
 
-  setup() {
-    this.baseImageUrl = this.setupOriginalImageUrl();
+  setup(_, existingIcon) {
+    this.originalImageUrl = this.setupOriginalImageUrl(existingIcon);
     const originalImage = this.originalImageTarget;
-    originalImage.src = this.baseImageUrl;
+    originalImage.src = this.originalImageUrl;
     originalImage.style.display = "inline";
 
     originalImage.onload = () => {
@@ -29,11 +26,10 @@ export default class extends Controller {
     };
   }
 
-  setupOriginalImageUrl() {
-    if (this.hasExistingIcon)
-      return this.existingIconTarget.dataset.originalIconUrl;
+  setupOriginalImageUrl(existingIcon) {
+    if (existingIcon) return existingIcon.dataset.imageUrl;
 
-    const file = this.uploadedIconTarget.files[0];
+    const file = this.uploadedImageTarget.files[0];
     if (!this.validateFile(file)) {
       alert(`${this.errorMessage}`);
       throw new Error(this.errorMessage);
@@ -44,7 +40,6 @@ export default class extends Controller {
   validateFile(file) {
     this.errorMessage = null;
     const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp"];
-    // file.nameがない？
     const fileExtension = file.name.split(".").pop().toLowerCase();
 
     if (fileExtension === "heic" || fileExtension === "heif") {
@@ -86,20 +81,20 @@ export default class extends Controller {
       enableLink(this.downloadLinkTarget);
     }, 3000);
     setTimeout(() => {
-      URL.revokeObjectURL(this.baseImageUrl);
+      URL.revokeObjectURL(this.originalImageUrl);
       URL.revokeObjectURL(previewImageUrl);
     }, 100);
   }
 
-  async triggerSubmit(combinedImageName) {
+  async triggerSubmit(combinedIconName) {
     const params = {};
-    if (this.hasExistingIcon) {
-      params.originalImageId = this.existingIconTarget.dataset.originalIconId;
+    if (this.hasExistingIconTarget) {
+      params.originalIconId = this.existingIconTarget.dataset.id;
     } else {
-      params.originalImageFile = this.uploadedIconTarget.files[0];
+      params.originalIconFile = this.uploadedImageTarget.files[0];
     }
-    params.combinedImageFile = this.canvasOutlet.canvasBlob;
-    params.combinedImageName = combinedImageName;
+    params.combinedIconFile = this.canvasOutlet.canvasBlob;
+    params.combinedIconName = combinedIconName;
     params.renderPlan = this.canvasOutlet.renderPlan;
 
     this.dispatch("download", {

--- a/app/javascript/controllers/icons_controller.js
+++ b/app/javascript/controllers/icons_controller.js
@@ -12,11 +12,25 @@ export default class extends Controller {
   static outlets = ["preview", "canvas"];
 
   connect() {
-    if (this.hasExistingIconTarget) this.setup(null, this.existingIconTarget);
+    if (this.hasExistingIconTarget)
+      this.setup({ existingIcon: this.existingIconTarget });
   }
 
-  setup(_, existingIcon) {
-    this.originalImageUrl = this.setupOriginalImageUrl(existingIcon);
+  upload() {
+    const uploadFile = this.uploadedImageTarget.files[0];
+    if (!this.validateFile(uploadFile)) {
+      alert(`${this.errorMessage}`);
+      throw new Error(this.errorMessage);
+    }
+
+    this.setup({ uploadFile });
+  }
+
+  setup({ uploadFile, existingIcon }) {
+    this.originalImageUrl = this.setupOriginalImageUrl(
+      uploadFile,
+      existingIcon,
+    );
     const originalImage = this.originalImageTarget;
     originalImage.src = this.originalImageUrl;
     originalImage.style.display = "inline";
@@ -26,15 +40,10 @@ export default class extends Controller {
     };
   }
 
-  setupOriginalImageUrl(existingIcon) {
-    if (existingIcon) return existingIcon.dataset.imageUrl;
+  setupOriginalImageUrl(uploadFile, existingIcon) {
+    if (uploadFile) return URL.createObjectURL(uploadFile);
 
-    const file = this.uploadedImageTarget.files[0];
-    if (!this.validateFile(file)) {
-      alert(`${this.errorMessage}`);
-      throw new Error(this.errorMessage);
-    }
-    return URL.createObjectURL(file);
+    if (existingIcon) return existingIcon.dataset.imageUrl;
   }
 
   validateFile(file) {
@@ -88,10 +97,11 @@ export default class extends Controller {
 
   async triggerSubmit(combinedIconName) {
     const params = {};
-    if (this.hasExistingIconTarget) {
+    const uploadedFile = this.uploadedImageTarget.files?.[0];
+    if (uploadedFile) {
+      params.originalIconFile = uploadedFile;
+    } else if (this.hasExistingIconTarget) {
       params.originalIconId = this.existingIconTarget.dataset.id;
-    } else {
-      params.originalIconFile = this.uploadedImageTarget.files[0];
     }
     params.combinedIconFile = this.canvasOutlet.canvasBlob;
     params.combinedIconName = combinedIconName;

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["toast", "toastMessage"];
 
   async submit(event) {
-    const fd = setupFormdata(event.detail.params)
+    const fd = setupFormdata(event.detail.params);
     const token = document.querySelector('meta[name="csrf-token"]').content;
     try {
       const response = await fetch("/icons", {
@@ -43,13 +43,13 @@ export default class extends Controller {
 
 function setupFormdata(params) {
   const fd = new FormData();
-  fd.append("combined_icon[image]", params.combinedImageFile);
-  fd.append("combined_icon[name]", params.combinedImageName);
+  fd.append("combined_icon[image]", params.combinedIconFile);
+  fd.append("combined_icon[name]", params.combinedIconName);
 
-  if (params.originalImageId) {
-    fd.append("original_icon[id]", params.originalImageId);
+  if (params.originalIconId) {
+    fd.append("original_icon[id]", params.originalIconId);
   } else {
-    fd.append("original_icon[image]", params.originalImageFile);
+    fd.append("original_icon[image]", params.originalIconFile);
   }
 
   fd.append("canvas_preset[text]", params.renderPlan.text?.text ?? "");

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["toast", "toastMessage"];
 
   async submit(event) {
-    const fd = setupFormdata(event.detail);
+    const fd = setupFormdata(event.detail.params)
     const token = document.querySelector('meta[name="csrf-token"]').content;
     try {
       const response = await fetch("/icons", {
@@ -41,21 +41,25 @@ export default class extends Controller {
   }
 }
 
-function setupFormdata(detail) {
+function setupFormdata(params) {
   const fd = new FormData();
-  fd.append("combined_icon[image]", detail.combinedImageFile);
-  fd.append("combined_icon[name]", detail.combinedImageName);
+  fd.append("combined_icon[image]", params.combinedImageFile);
+  fd.append("combined_icon[name]", params.combinedImageName);
 
-  fd.append("original_icon[image]", detail.originalImageFile);
+  if (params.originalImageId) {
+    fd.append("original_icon[id]", params.originalImageId);
+  } else {
+    fd.append("original_icon[image]", params.originalImageFile);
+  }
 
-  fd.append("canvas_preset[text]", detail.renderPlan.text?.text ?? "");
+  fd.append("canvas_preset[text]", params.renderPlan.text?.text ?? "");
   fd.append(
     "canvas_preset[text_color]",
-    detail.renderPlan.text?.fillStyle ?? "",
+    params.renderPlan.text?.fillStyle ?? "",
   );
   fd.append(
     "canvas_preset[bg_color]",
-    detail.renderPlan.background?.fillStyle ?? "",
+    params.renderPlan.background?.fillStyle ?? "",
   );
 
   return fd;

--- a/app/models/combined_icon.rb
+++ b/app/models/combined_icon.rb
@@ -10,6 +10,7 @@ class CombinedIcon < ApplicationRecord
     attachable.variant :thumb, resize_to_limit: [200, 200], preprocessed: true
   end
 
+  validates :image, presence: true
   validates :image, image_content: { max_file_size: MAX_FILE_SIZE }
   validate :limit_per_user, on: :create
 

--- a/app/models/original_icon.rb
+++ b/app/models/original_icon.rb
@@ -11,6 +11,7 @@ class OriginalIcon < ApplicationRecord
     attachable.variant :thumb, resize_to_limit: [200, 200], preprocessed: true
   end
 
+  validates :image, presence: true
   validates :image, image_content: { max_file_size: MAX_FILE_SIZE }
   # TODO　動作確認のためコメントアウトしている 後で直す(issue起票済み)
   # validate :limit_per_user, on: :create

--- a/app/models/user_icons.rb
+++ b/app/models/user_icons.rb
@@ -9,7 +9,8 @@ class UserIcons
 
   def save_all(original_icon_params, combined_icon_params)
     ActiveRecord::Base.transaction do
-      @original_icon = @user.original_icons.create!(original_icon_params)
+      @original_icon = @user.original_icons.find_by(id: original_icon_params[:id]) ||
+                       @user.original_icons.create!(original_icon_params.except(:id))
       @combined_icon = @original_icon.combined_icons.create!(combined_icon_params)
     end
     true

--- a/app/views/icons/index.html.slim
+++ b/app/views/icons/index.html.slim
@@ -6,6 +6,8 @@
     = image_tag original_icon.image.variant(:thumb)
     = link_to icon_path(original_icon, original_icon_id: original_icon.id), data: { turbo_method: :delete, turbo_confirm: 'オリジナルアイコンを削除すると関連する合成アイコンも削除されます。本当によろしいですか？' } do
       | 削除
+    = link_to new_icon_path(original_icon_id: original_icon.id)
+      | 合成
     br
     h3 合成したアイコン
     - if combined_icons.present?

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -20,8 +20,8 @@ div(
   - if @original_icon
     div(
       data-icons-target='existingIcon'
-      data-original-icon-url=url_for(@original_icon.image)
-      data-original-icon-id=@original_icon.id
+      data-image-url=url_for(@original_icon.image)
+      data-id=@original_icon.id
       )
 
   label for='upload-icon' アイコンをアップロード

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -25,7 +25,7 @@ div(
       )
 
   label for='upload-icon' アイコンをアップロード
-  input#upload-icon type='file' accept='image/*' data-icons-target='uploadedImage' data-action='change->icons#setup'
+  input#upload-icon type='file' accept='image/*' data-icons-target='uploadedImage' data-action='change->icons#upload'
   h3 元画像
   img.icon data-icons-target='originalImage' alt='icon' style='max-width:360px;display:none;'
   h3 プレビュー画像

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -17,8 +17,15 @@ div(
   #toast
     = render 'layouts/toast'
 
+  - if @original_icon
+    div(
+      data-icons-target='existingIcon'
+      data-original-icon-url=url_for(@original_icon.image)
+      data-original-icon-id=@original_icon.id
+      )
+
   label for='upload-icon' アイコンをアップロード
-  input#upload-icon type='file' accept='image/*' data-icons-target='uploadedIcon' data-action='change->icons#setup'
+  input#upload-icon type='file' accept='image/*' data-icons-target='uploadedImage' data-action='change->icons#setup'
   h3 元画像
   img.icon data-icons-target='originalImage' alt='icon' style='max-width:360px;display:none;'
   h3 プレビュー画像

--- a/spec/models/user_icons_spec.rb
+++ b/spec/models/user_icons_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe UserIcons do
   let(:user) { create(:user) }
 
   describe '#save_all' do
-    context 'when params are valid' do
-      subject(:save_all) { user_icons.save_all(original_icon_params, combined_icon_params) }
+    subject(:save_all) { user_icons.save_all(original_icon_params, combined_icon_params) }
 
+    context 'when creating a new original_icon' do
       let(:original_icon_params) do
         attributes_for(:original_icon).merge(
           image: fixture_file_upload('spec/files/dummy_3MB.jpg', 'image/jpeg')
@@ -33,10 +33,30 @@ RSpec.describe UserIcons do
       end
     end
 
-    context 'when params are invalid' do
-      subject(:save_all) { user_icons.save_all(valid_original_icon_params, invalid_combined_icon_params) }
+    context 'when using an existing original_icon' do
+      let!(:original_icon) { create(:original_icon, user:) }
+      let(:original_icon_params) { { id: original_icon.id } }
+      let(:combined_icon_params) do
+        attributes_for(:combined_icon).merge(
+          image: fixture_file_upload('spec/files/dummy_3MB.jpg', 'image/jpeg')
+        )
+      end
 
-      let(:valid_original_icon_params) do
+      it 'returns true' do
+        expect(save_all).to be true
+      end
+
+      it 'creates a combined_icon associated with the found original_icon' do
+        expect { save_all }
+          .to not_change(OriginalIcon, :count)
+          .and change(CombinedIcon, :count).by(1)
+      end
+    end
+
+    context 'when params are invalid' do
+      subject(:save_all) { user_icons.save_all(original_icon_params, invalid_combined_icon_params) }
+
+      let(:original_icon_params) do
         attributes_for(:original_icon).merge(
           image: fixture_file_upload('spec/files/dummy_3MB.jpg', 'image/jpeg')
         )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,3 +51,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.infer_spec_type_from_file_location!
 end
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
- #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アイコン一覧から既存アイコンをベースに新しい合成アイコンを作成できる「合成」操作を追加しました。

* **改善**
  * 合成フローのアップロード／既存アイコンの選択がよりスムーズになりました。
  * 送信データ構造やフォーム処理を整理し、操作の一貫性を向上しました。
  * 画像添付に対する検証を強化し、不整合な入力を防止します。

* **テスト**
  * 既存アイコン利用時の振る舞いを検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mousu-a/combine_icons_with_text/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->