### PR TITLE
一覧ページ、ヘッダー(暫定)のデザイン

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -31,7 +31,7 @@
   z-index: 1000;
 
   padding: 12px 16px;
-  border-radius: 8px;
+  border-radius: 6px;
 
   background: #333;
   color: #fff;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -24,4 +24,16 @@
   .link-button {
     @apply inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-gray-300 hover:bg-gray-50;
   }
+
+  .divider-b {
+    @apply border-b border-gray-200;
+  }
+
+  .divider-t {
+    @apply border-t border-gray-200;
+  }
+
+  .frame-border {
+    @apply rounded-lg border border-gray-200;
+  }
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -10,7 +10,7 @@
   }
 
   .btn-text-option {
-    @apply cursor-pointer rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700;
+    @apply cursor-pointer rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700;
   }
 
   .color-picker-label {
@@ -18,6 +18,10 @@
   }
 
   .color-picker {
-    @apply h-8 w-12 cursor-pointer rounded-lg border border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50;
+    @apply h-8 w-12 cursor-pointer rounded-md border border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50;
+  }
+
+  .link-button {
+    @apply inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-gray-300 hover:bg-gray-50;
   }
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -36,4 +36,8 @@
   .frame-border {
     @apply rounded-lg border border-gray-200;
   }
+
+  .text-primary {
+    @apply text-indigo-600;
+  }
 }

--- a/app/views/icons/index.html.slim
+++ b/app/views/icons/index.html.slim
@@ -1,7 +1,7 @@
 - set_meta_tags title: 'アイコン一覧'
 - set_meta_tags description: 'サイトに保存したアイコンを一覧表示するページです。'
 
-header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.mb-6(class='h-[4.4375rem]')
+header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[4.4375rem]')
   h1.text-2xl.font-bold.tracking-tight.text-indigo-700
     | アイコン一覧
   = link_to new_icon_path, class: 'link-button' do
@@ -9,17 +9,17 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
 
 .mx-auto.max-w-5xl.rounded-md.px-6.py-6
   - if @saved_icons.blank?
-    .rounded-lg.border.border-gray-200.bg-gray-50.p-8.text-center
+    .frame-border.bg-gray-50.p-8.text-center
       p.text-sm.text-gray-500
         | 保存されているアイコンはありません
   - else
     div class="grid gap-6 grid-cols-[repeat(auto-fit,minmax(22rem,1fr))]"
       - @saved_icons.each do |original_icon, combined_icons|
-        section.rounded-lg.border.border-gray-200.bg-white.p-6.shadow-sm
+        section.frame-border.bg-white.p-6.shadow-sm
           h2.mb-3.pl-2.text-sm.font-semibold.text-gray-800
             | 元アイコン
-          .flex.flex-wrap.items-center.gap-4.border-b.border-gray-100.pb-6.mb-6
-            figure.m-0.flex.aspect-square.w-32.shrink-0.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-2
+          .flex.flex-wrap.items-center.gap-4.divider-b.pb-6.mb-6
+            figure.m-0.flex.aspect-square.w-32.shrink-0.items-center.justify-center.frame-border.bg-gray-50.p-2
               = image_tag original_icon.image.variant(:thumb), class: 'max-w-full rounded'
             .flex.h-32.flex-col.items-start.gap-2
               .flex.flex-row.items-start.gap-2
@@ -39,7 +39,7 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
               - icon_frame_padding_x = 'px-2'
               - combined_icons.each do |combined_icon|
                 li.flex.flex-col.gap-1
-                  figure(class="m-0 flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50 py-2 #{icon_frame_padding_x}")
+                  figure(class="m-0 flex aspect-square w-full items-center justify-center frame-border bg-gray-50 py-2 #{icon_frame_padding_x}")
                     = image_tag combined_icon.image.variant(:thumb), class: 'max-w-full rounded'
                   div(class="flex items-center justify-end gap-2 #{icon_frame_padding_x}")
                     = link_to rails_blob_path(combined_icon.image.variant(:thumb), disposition: 'attachment'), class: 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-50' do
@@ -52,7 +52,7 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
             p.text-sm.text-gray-500
               | まだ合成したアイコンがありません
 
-  section.border-t.border-gray-100.pt-6
+  section.divider-t.pt-6
     h2.mb-3.text-sm.font-semibold.text-gray-800
       | 各リンク
     = render 'icon_change_links', links: @links

--- a/app/views/icons/index.html.slim
+++ b/app/views/icons/index.html.slim
@@ -1,24 +1,58 @@
 - set_meta_tags title: 'アイコン一覧'
 - set_meta_tags description: 'サイトに保存したアイコンを一覧表示するページです。'
 
-- if @saved_icons.blank?
-  p 保存されているアイコンはありません
-- else
-  - @saved_icons.each do |original_icon, combined_icons|
-    h2 オリジナルのアイコン
-    = image_tag original_icon.image.variant(:thumb)
-    = link_to icon_path(original_icon, original_icon_id: original_icon.id), data: { turbo_method: :delete, turbo_confirm: 'オリジナルアイコンを削除すると関連する合成アイコンも削除されます。本当によろしいですか？' } do
-      | 削除
-    = link_to new_icon_path(original_icon_id: original_icon.id)
-      | 合成
-    br
-    h3 合成したアイコン
-    - if combined_icons.present?
-      - combined_icons.each do |combined_icon|
-        = image_tag combined_icon.image.variant(:thumb)
-        = link_to icon_path(combined_icon, original_icon_id: original_icon.id, combined_icon_id: combined_icon.id), data: { turbo_method: :delete, turbo_confirm: 'この合成アイコンを削除します。本当によろしいですか？' } do
-          | 削除
-    - else
-      p まだ合成したアイコンがありません
+header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.mb-6(class='h-[4.4375rem]')
+  h1.text-2xl.font-bold.tracking-tight.text-indigo-700
+    | アイコン一覧
+  = link_to new_icon_path, class: 'link-button' do
+    | + アイコンに文字を合成する
 
-= render 'icon_change_links', links: @links
+.mx-auto.max-w-5xl.rounded-md.px-6.py-6
+  - if @saved_icons.blank?
+    .rounded-lg.border.border-gray-200.bg-gray-50.p-8.text-center
+      p.text-sm.text-gray-500
+        | 保存されているアイコンはありません
+  - else
+    div class="grid gap-6 grid-cols-[repeat(auto-fit,minmax(22rem,1fr))]"
+      - @saved_icons.each do |original_icon, combined_icons|
+        section.rounded-lg.border.border-gray-200.bg-white.p-6.shadow-sm
+          h2.mb-3.pl-2.text-sm.font-semibold.text-gray-800
+            | 元アイコン
+          .flex.flex-wrap.items-center.gap-4.border-b.border-gray-100.pb-6.mb-6
+            figure.m-0.flex.aspect-square.w-32.shrink-0.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-2
+              = image_tag original_icon.image.variant(:thumb), class: 'max-w-full rounded'
+            .flex.h-32.flex-col.items-start.gap-2
+              .flex.flex-row.items-start.gap-2
+                = link_to new_icon_path(original_icon_id: original_icon.id), class:'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50'  do
+                  | 合成する
+                = link_to rails_blob_path(original_icon.image, disposition: 'attachment'), class: 'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50' do
+                  | ダウンロード
+              = link_to icon_path(original_icon, original_icon_id: original_icon.id),
+                data: { turbo_method: :delete, turbo_confirm: 'オリジナルアイコンを削除すると関連する合成アイコンも削除されます。本当によろしいですか？' },
+                class: 'inline-flex items-center gap-1 rounded-md px-4 py-2 text-sm font-medium text-gray-400 underline transition hover:text-gray-500' do
+                | 削除
+
+          h3.mb-3.pl-2.text-sm.font-semibold.text-gray-800
+            | 合成したアイコン一覧
+          - if combined_icons.present?
+            ul class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(6rem,8rem))]"
+              - icon_frame_padding_x = 'px-2'
+              - combined_icons.each do |combined_icon|
+                li.flex.flex-col.gap-1
+                  figure(class="m-0 flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50 py-2 #{icon_frame_padding_x}")
+                    = image_tag combined_icon.image.variant(:thumb), class: 'max-w-full rounded'
+                  div(class="flex items-center justify-end gap-2 #{icon_frame_padding_x}")
+                    = link_to rails_blob_path(combined_icon.image.variant(:thumb), disposition: 'attachment'), class: 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-50' do
+                      | ダウンロード
+                    = link_to icon_path(combined_icon, original_icon_id: original_icon.id, combined_icon_id: combined_icon.id),
+                      data: { turbo_method: :delete, turbo_confirm: 'この合成アイコンを削除します。本当によろしいですか？' },
+                      class: 'whitespace-nowrap text-xs font-medium text-gray-400 underline hover:text-gray-500' do
+                      | 削除
+          - else
+            p.text-sm.text-gray-500
+              | まだ合成したアイコンがありません
+
+  section.border-t.border-gray-100.pt-6
+    h2.mb-3.text-sm.font-semibold.text-gray-800
+      | 各リンク
+    = render 'icon_change_links', links: @links

--- a/app/views/icons/index.html.slim
+++ b/app/views/icons/index.html.slim
@@ -23,9 +23,10 @@ header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[
               = image_tag original_icon.image.variant(:thumb), class: 'max-w-full rounded'
             .flex.h-32.flex-col.items-start.gap-2
               .flex.flex-row.items-start.gap-2
-                = link_to new_icon_path(original_icon_id: original_icon.id), class:'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-primary shadow-sm transition hover:bg-indigo-50'  do
+                - icon_action_link_class = 'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-primary shadow-sm transition hover:bg-indigo-50'
+                = link_to new_icon_path(original_icon_id: original_icon.id), class: icon_action_link_class do
                   | 合成する
-                = link_to rails_blob_path(original_icon.image, disposition: 'attachment'), class: 'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-primary shadow-sm transition hover:bg-indigo-50' do
+                = link_to rails_blob_path(original_icon.image, disposition: 'attachment'), class: icon_action_link_class do
                   | ダウンロード
               = link_to icon_path(original_icon, original_icon_id: original_icon.id),
                 data: { turbo_method: :delete, turbo_confirm: 'オリジナルアイコンを削除すると関連する合成アイコンも削除されます。本当によろしいですか？' },
@@ -36,13 +37,14 @@ header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[
             | 合成したアイコン一覧
           - if combined_icons.present?
             ul class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(6rem,8rem))]"
-              - icon_frame_padding_x = 'px-2'
+              - icon_frame_padding_x_class = 'px-2'
+              - combined_icon_download_class = 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-primary transition hover:bg-indigo-50'
               - combined_icons.each do |combined_icon|
                 li.flex.flex-col.gap-1
-                  figure(class="m-0 flex aspect-square w-full items-center justify-center frame-border bg-gray-50 py-2 #{icon_frame_padding_x}")
+                  figure(class="m-0 flex aspect-square w-full items-center justify-center frame-border bg-gray-50 py-2 #{icon_frame_padding_x_class}")
                     = image_tag combined_icon.image.variant(:thumb), class: 'max-w-full rounded'
-                  div(class="flex items-center justify-end gap-2 #{icon_frame_padding_x}")
-                    = link_to rails_blob_path(combined_icon.image.variant(:thumb), disposition: 'attachment'), class: 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-primary transition hover:bg-indigo-50' do
+                  div(class="flex items-center justify-end gap-2 #{icon_frame_padding_x_class}")
+                    = link_to rails_blob_path(combined_icon.image, disposition: 'attachment'), class: combined_icon_download_class do
                       | ダウンロード
                     = link_to icon_path(combined_icon, original_icon_id: original_icon.id, combined_icon_id: combined_icon.id),
                       data: { turbo_method: :delete, turbo_confirm: 'この合成アイコンを削除します。本当によろしいですか？' },

--- a/app/views/icons/index.html.slim
+++ b/app/views/icons/index.html.slim
@@ -2,7 +2,7 @@
 - set_meta_tags description: 'サイトに保存したアイコンを一覧表示するページです。'
 
 header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[4.4375rem]')
-  h1.text-2xl.font-bold.tracking-tight.text-indigo-700
+  h1.text-2xl.font-bold.tracking-tight.text-primary
     | アイコン一覧
   = link_to new_icon_path, class: 'link-button' do
     | + アイコンに文字を合成する
@@ -23,9 +23,9 @@ header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[
               = image_tag original_icon.image.variant(:thumb), class: 'max-w-full rounded'
             .flex.h-32.flex-col.items-start.gap-2
               .flex.flex-row.items-start.gap-2
-                = link_to new_icon_path(original_icon_id: original_icon.id), class:'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50'  do
+                = link_to new_icon_path(original_icon_id: original_icon.id), class:'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-primary shadow-sm transition hover:bg-indigo-50'  do
                   | 合成する
-                = link_to rails_blob_path(original_icon.image, disposition: 'attachment'), class: 'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-indigo-600 shadow-sm transition hover:bg-indigo-50' do
+                = link_to rails_blob_path(original_icon.image, disposition: 'attachment'), class: 'inline-flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold text-primary shadow-sm transition hover:bg-indigo-50' do
                   | ダウンロード
               = link_to icon_path(original_icon, original_icon_id: original_icon.id),
                 data: { turbo_method: :delete, turbo_confirm: 'オリジナルアイコンを削除すると関連する合成アイコンも削除されます。本当によろしいですか？' },
@@ -42,7 +42,7 @@ header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-6(class='h-[
                   figure(class="m-0 flex aspect-square w-full items-center justify-center frame-border bg-gray-50 py-2 #{icon_frame_padding_x}")
                     = image_tag combined_icon.image.variant(:thumb), class: 'max-w-full rounded'
                   div(class="flex items-center justify-end gap-2 #{icon_frame_padding_x}")
-                    = link_to rails_blob_path(combined_icon.image.variant(:thumb), disposition: 'attachment'), class: 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-50' do
+                    = link_to rails_blob_path(combined_icon.image.variant(:thumb), disposition: 'attachment'), class: 'inline-flex items-center justify-center whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-primary transition hover:bg-indigo-50' do
                       | ダウンロード
                     = link_to icon_path(combined_icon, original_icon_id: original_icon.id, combined_icon_id: combined_icon.id),
                       data: { turbo_method: :delete, turbo_confirm: 'この合成アイコンを削除します。本当によろしいですか？' },

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -1,16 +1,14 @@
 - set_meta_tags title: 'アイコン合成'
 - set_meta_tags description: 'アイコンにテキストを合成するページです。'
 
-.mx-auto.max-w-5xl.pb-5
-  .flex.items-center.justify-between.border-b.border-gray-200.py-4.mb-4
-    h1.text-center.text-2xl.font-bold.tracking-tight.text-indigo-700
-      | アイコン合成
-    - back_to_list_class = 'inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition ' \
-        'hover:border-gray-300 hover:bg-gray-50'
-    = link_to '← アイコン一覧へ', icons_path, class: back_to_list_class
+header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.mb-4(class='h-[4.4375rem]')
+  h1.text-center.text-2xl.font-bold.tracking-tight.text-indigo-700
+    | アイコン合成
+  = link_to '← アイコン一覧へ', icons_path, class: 'link-button'
 
+.mx-auto.max-w-5xl.rounded-md.p-6.bg-white
   - if @user_icons&.errors&.any?
-    .mb-4.rounded-xl.border.border-red-200.bg-red-50.p-4 role='alert'
+    .mb-4.rounded-lg.border.border-red-200.bg-red-50.p-4 role='alert'
       p.mb-2.font-semibold.text-red-800
         | 入力内容にエラーがありました
       ul.list-inside.list-disc.text-sm.text-red-700
@@ -18,7 +16,7 @@
           li.mb-1 = msg
 
   - if @limit_reached
-    .mb-6.rounded-xl.border.border-amber-200.bg-amber-50.p-4.text-sm.leading-relaxed.text-amber-900 role='status'
+    .mb-6.rounded-lg.border.border-amber-200.bg-amber-50.p-4.text-sm.leading-relaxed.text-amber-900 role='status'
       p
         | すでにサイト上に、アイコンが上限まで保存されております。
         br
@@ -55,7 +53,7 @@
       data-icons-target='uploadedImage'
       data-action='change->icons#upload'
       )
-    - upload_button_class = 'inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg mb-3 text-white font-bold bg-indigo-600 px-4 py-2.5 text-sm font-semibold transition ' \
+    - upload_button_class = 'inline-flex cursor-pointer items-center justify-center gap-2 rounded-md mb-3 text-white font-bold bg-indigo-600 px-4 py-2.5 text-sm font-semibold transition ' \
         'hover:bg-indigo-700 peer-focus-visible:ring-2 peer-focus-visible:ring-indigo-700 peer-focus-visible:ring-offset-2'
     label(class=upload_button_class for='upload-icon')
       | アイコンを選択
@@ -64,12 +62,12 @@
       div
         h2.section-heading
           | 元画像
-        .mx-auto.flex.aspect-square.w-full.max-w-40.items-center.justify-center.rounded-xl.border.border-gray-200.bg-gray-50.p-3(
+        .mx-auto.flex.aspect-square.w-full.max-w-40.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-3(
           data-icons-target='originalImageFrame'
         )
           img(
             id='icon'
-            class='max-w-[360px] hidden rounded-md'
+            class='max-w-[360px] hidden rounded'
             data-icons-target='originalImage'
             alt='icon'
             )
@@ -77,12 +75,12 @@
       div
         h2.section-heading
           | プレビュー画像
-        .mx-auto.flex.aspect-square.w-full.max-w-52.items-center.justify-center.rounded-xl.border.border-gray-200.bg-gray-50.p-3(
+        .mx-auto.flex.aspect-square.w-full.max-w-52.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-3(
           data-preview-target='previewImageFrame'
         )
           img(
             id='icon-preview'
-            class='max-w-[360px] hidden rounded-md object-cover'
+            class='max-w-[360px] hidden rounded object-cover'
             data-preview-target='previewImage'
             alt='preview icon'
             )
@@ -121,7 +119,7 @@
         .mb-4
           h3.option-heading
             | 背景を追加
-          - bg_button_class = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-indigo-300 ' \
+          - bg_button_class = 'w-full rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-indigo-300 ' \
               'hover:bg-indigo-50 hover:text-indigo-700 cursor-pointer'
           button(
             type='button'
@@ -172,7 +170,7 @@
           - @canvas_presets.each do |canvas_preset|
             li
               canvas(
-                class='w-32 max-w-[360px] shrink-0 cursor-pointer rounded-lg border border-gray-200 bg-white shadow-sm transition hover:border-indigo-300 hover:shadow-md'
+                class='w-32 max-w-[360px] shrink-0 cursor-pointer rounded-md border border-gray-200 bg-white shadow-sm transition hover:border-indigo-300 hover:shadow-md'
                 data-action='click->canvas#applyPreset'
                 data-presets-renderer-target='presetCanvas'
                 data-text=canvas_preset.text
@@ -185,7 +183,7 @@
     .border-t.border-b.border-gray-100.py-5
       small.mb-3.block.text-xs.text-gray-500
         | ログイン済みの場合、ダウンロードすると画像がサイトに保存されます。
-      - download_link_class = 'is-disabled inline-flex items-center justify-center rounded-lg bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 ' \
+      - download_link_class = 'is-disabled inline-flex items-center justify-center rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 ' \
           'aria-disabled:cursor-not-allowed aria-disabled:bg-gray-300 aria-disabled:hover:bg-gray-300'
       = link_to '画像をダウンロード',
         '#',

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -1,7 +1,7 @@
 - set_meta_tags title: 'アイコン合成'
 - set_meta_tags description: 'アイコンにテキストを合成するページです。'
 
-header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.mb-4(class='h-[4.4375rem]')
+header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-4(class='h-[4.4375rem]')
   h1.text-center.text-2xl.font-bold.tracking-tight.text-indigo-700
     | アイコン合成
   = link_to '← アイコン一覧へ', icons_path, class: 'link-button'
@@ -58,11 +58,11 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
     label(class=upload_button_class for='upload-icon')
       | アイコンを選択
 
-    .grid.grid-cols-2.gap-6.border-t.border-gray-100.py-6.lg:grid-cols-3
+    .grid.grid-cols-2.gap-6.divider-t.py-6.lg:grid-cols-3
       div
         h2.section-heading
           | 元画像
-        .mx-auto.flex.aspect-square.w-full.max-w-40.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-3(
+        .mx-auto.flex.aspect-square.w-full.max-w-40.items-center.justify-center.frame-border.bg-gray-50.p-3(
           data-icons-target='originalImageFrame'
         )
           img(
@@ -75,7 +75,7 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
       div
         h2.section-heading
           | プレビュー画像
-        .mx-auto.flex.aspect-square.w-full.max-w-52.items-center.justify-center.rounded-lg.border.border-gray-200.bg-gray-50.p-3(
+        .mx-auto.flex.aspect-square.w-full.max-w-52.items-center.justify-center.frame-border.bg-gray-50.p-3(
           data-preview-target='previewImageFrame'
         )
           img(
@@ -163,7 +163,7 @@ header.flex.items-center.justify-between.border-b.border-gray-200.bg-white.px-6.
             )
 
     - if @canvas_presets.present?
-      .border-t.border-gray-100.py-4
+      .divider-t.py-4
         h2.mb-3.text-sm.font-semibold.text-gray-800
           | 他の人が作ったプリセット
         ul.flex.flex-nowrap.gap-3.overflow-x-auto.list-none.p-0.m-0

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -2,7 +2,7 @@
 - set_meta_tags description: 'アイコンにテキストを合成するページです。'
 
 header.flex.items-center.justify-between.divider-b.bg-white.px-6.mb-4(class='h-[4.4375rem]')
-  h1.text-center.text-2xl.font-bold.tracking-tight.text-indigo-700
+  h1.text-center.text-2xl.font-bold.tracking-tight.text-primary
     | アイコン合成
   = link_to '← アイコン一覧へ', icons_path, class: 'link-button'
 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,5 +1,5 @@
 header.header
-  .px-6.pb-4.border-b.border-gray-200.bg-white
+  .px-6.pb-4.divider-b.bg-white
     div(class='flex items-center justify-between' data-controller='dropdown')
       = link_to image_tag('logo.png', class: 'w-20 h-20 rounded-md', alt: '文字入りアイコンメーカーのロゴ'), root_path
       - if current_user

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,11 +1,11 @@
 header.header
-  .mx-auto.max-w-5xl.border-b.border-gray-200
+  .px-6.pb-4.border-b.border-gray-200.bg-white
     div(class='flex items-center justify-between' data-controller='dropdown')
-      = link_to image_tag('logo.png', class: 'w-20 h-20', alt: '文字入りアイコンメーカーのロゴ'), root_path
+      = link_to image_tag('logo.png', class: 'w-20 h-20 rounded-md', alt: '文字入りアイコンメーカーのロゴ'), root_path
       - if current_user
         .flex.items-center.gap-3
           = button_tag type: 'button', class: 'avatar-icon', data: { dropdown_target: 'avatarIcon', action: 'click->dropdown#toggleLogoutButton' } do
-            = image_tag current_user.avatar_url, alt: 'アバター画像'
+            = image_tag current_user.avatar_url, alt: 'アバター画像', class: 'w-20 h-20 rounded-md'
           = link_to 'ログアウト', logout_path, data: { turbo_method: :delete, dropdown_target: 'logoutButton' }, class: 'logout is-hidden'
       - else
         = link_to 'ログイン', welcome_path, class: 'text-sm font-medium text-gray-700 hover:text-gray-900'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,10 +16,10 @@ html
     = stylesheet_link_tag 'tailwind', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
     = display_meta_tags default_meta_tags
-  body
+  body.bg-gray-100
     - unless current_page?(welcome_path)
       = render 'layouts/header'
-    main
+    main.min-h-screen.border-gray-200
       #flash
         = render 'layouts/flash'
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -19,7 +19,7 @@ html
   body.bg-gray-100
     - unless current_page?(welcome_path)
       = render 'layouts/header'
-    main.min-h-screen.border-gray-200
+    main.min-h-screen
       #flash
         = render 'layouts/flash'
       = yield


### PR DESCRIPTION
closes #228 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保存アイコン一覧で、元アイコンと合成済みアイコンを見やすいカード・グリッド形式で確認できるようになりました。
  * 元アイコンや合成済みアイコンをダウンロードできるようになりました。
  * アイコンや合成済みアイコンを一覧から削除できるようになりました。
  * アイコンがない場合の案内表示を追加しました。

* **スタイル改善**
  * ヘッダー、ボタン、画像、通知などの角丸や余白、背景色を調整し、画面全体のデザインを統一しました。
  * アイコン作成画面のエラー表示、プレビュー、プリセット表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->