### PR TITLE
保存失敗時や、fetchの失敗時のユーザーへの説明

### DIFF
--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -25,7 +25,9 @@ export default class extends Controller {
       }
     } catch (error) {
       console.error("Upload error:", error);
-      alert("通信エラーが発生しました。");
+      alert(
+        "通信エラーが発生したため画像を保存出来ませんでした。\n画像を保存したい場合は時間を置いて再度ダウンロードボタンを押してください。",
+      );
       // TODO: ユーザーのネクストアクションを誘導する
       // https://github.com/mousu-a/combine_icons_with_text/issues/127
     }

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -20,16 +20,12 @@ export default class extends Controller {
         this.displayToast(responseData.message);
       } else {
         alert(responseData.error_message);
-        // TODO: ユーザーのネクストアクションを誘導する
-        // https://github.com/mousu-a/combine_icons_with_text/issues/127
       }
     } catch (error) {
       console.error("Upload error:", error);
       alert(
         "通信エラーが発生したため画像を保存出来ませんでした。\n画像を保存したい場合は時間を置いて再度ダウンロードボタンを押してください。",
       );
-      // TODO: ユーザーのネクストアクションを誘導する
-      // https://github.com/mousu-a/combine_icons_with_text/issues/127
     }
   }
 

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -48,9 +48,13 @@ header.page-header
     div data-controller='ui-state'
       p class='instruction-text mb-2' data-ui-state-target='instructionText'
         | まずはアイコンをアップロードしましょう
-      - upload_button_class = 'upload-button inline-flex cursor-pointer items-center justify-center gap-2 rounded-md mb-3 text-white font-bold px-4 py-2.5 text-sm font-semibold transition'
-      label(class=upload_button_class for='upload-icon' data-ui-state-target='uploadButton')
-        | アイコンを選択
+      - upload_button_class = 'upload-button inline-flex cursor-pointer items-center justify-center gap-2 rounded-md text-white font-bold px-4 py-2.5 text-sm font-semibold transition'
+      .mb-3.flex.flex-wrap.items-center.gap-3
+        label(class=upload_button_class for='upload-icon' data-ui-state-target='uploadButton')
+          | アイコンを選択
+        ol.list-inside.list-decimal.text-xs.leading-relaxed.text-gray-500
+          li 合成できるアイコンのサイズは6MBまでとなっております。
+          li ファイル形式は JPG, JPEG, PNG, WEBP にのみ対応しています。
       input#upload-icon.sr-only(
         type='file'
         accept='image/*'

--- a/app/views/icons/new.html.slim
+++ b/app/views/icons/new.html.slim
@@ -57,7 +57,7 @@ header.page-header
           li ファイル形式は JPG, JPEG, PNG, WEBP にのみ対応しています。
       input#upload-icon.sr-only(
         type='file'
-        accept='image/*'
+        accept='image/jpeg,image/png,image/webp'
         data-icons-target='uploadedImage'
         data-action='change->icons#upload change->ui-state#change'
         )


### PR DESCRIPTION
closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アイコン合成画面に、対応ファイル形式（JPG/JPEG/PNG/WEBP）と最大容量6MBの案内を追加しました。
  * アップロードボタン周辺のレイアウトを改善しました。
* **バグ修正**
  * アップロード失敗時のエラーメッセージを、画像を保存できない場合の対処方法が分かる内容に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->