### PR TITLE
合成アイコンのダウンロードファイルに拡張子が付かず開けない問題を解消

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -56,7 +56,7 @@ class IconsController < ApplicationController
   end
 
   def combined_icon_params
-    params.expect(combined_icon: %i[image name])
+    params.expect(combined_icon: %i[image])
   end
 
   def canvas_preset_params

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -41,7 +41,11 @@ export default class extends Controller {
 
 function setupFormdata(params) {
   const fd = new FormData();
-  fd.append("combined_icon[image]", params.combinedIconFile);
+  fd.append(
+    "combined_icon[image]",
+    params.combinedIconFile,
+    params.combinedIconName,
+  );
   fd.append("combined_icon[name]", params.combinedIconName);
 
   if (params.originalIconId) {

--- a/app/javascript/controllers/icons_form_controller.js
+++ b/app/javascript/controllers/icons_form_controller.js
@@ -46,7 +46,6 @@ function setupFormdata(params) {
     params.combinedIconFile,
     params.combinedIconName,
   );
-  fd.append("combined_icon[name]", params.combinedIconName);
 
   if (params.originalIconId) {
     fd.append("original_icon[id]", params.originalIconId);

--- a/db/migrate/20260729045449_remove_name_from_combined_icons.rb
+++ b/db/migrate/20260729045449_remove_name_from_combined_icons.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromCombinedIcons < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :combined_icons, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_020226) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_29_045449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,7 +53,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_020226) do
 
   create_table "combined_icons", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "name", null: false
     t.bigint "original_icon_id", null: false
     t.datetime "updated_at", null: false
     t.index ["original_icon_id"], name: "index_combined_icons_on_original_icon_id"

--- a/spec/factories/combined_icons.rb
+++ b/spec/factories/combined_icons.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :combined_icon do
     original_icon
-    name { 'ラジオ参加' }
 
     after(:build) do |combined_icon, evaluator|
       if evaluator.io


### PR DESCRIPTION
closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 複合アイコンのアップロード形式を変更しました。
  - 複合アイコン名を独立した項目として送信・保存せず、アップロードする画像のファイル名として扱うようになりました。
  - 既存の複合アイコン情報から「名前」項目が削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->